### PR TITLE
fix: ロゴとページヘッダーの文字が被らないように切り替え位置を調整

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -125,7 +125,7 @@ import imageLogo from "../images/gyroid-logo.png";
       const handleScroll = () => {
         // ヘッダー固定位置は、ページヘッダーの高さ - ヘッダーの高さ
         // @todo ここのエラー気になる
-        const fixedPos = pageHeader.offsetHeight - header.offsetHeight;
+        const fixedPos = header.offsetHeight;
         if (window.scrollY > fixedPos) {
           header.classList.add("fixed");
         } else {


### PR DESCRIPTION
## 概要
従来はロゴがページヘッダーの最下部に到達したらデザインが切り替わるようになっていたので、
ヘッダーの高さ分スクロールしたら切り替わるように調整した。
※まだ被っている気がするので引き続き調整が必要？