### PR TITLE
fix: ロゴとページヘッダーの文字が被らないように切り替え位置を調整

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -124,8 +124,9 @@ import imageLogo from "../images/gyroid-logo.png";
     if (pageHeader) {
       const handleScroll = () => {
         // ヘッダー固定位置は、ページヘッダーの高さ - ヘッダーの高さ
-        // @todo ここのエラー気になる
-        const fixedPos = header.offsetHeight;
+        // 15 = ロゴとヘッダーの間隔
+        // @todo ここのエラー気になる・実数値解消したい
+        const fixedPos = header.offsetHeight - 15;
         if (window.scrollY > fixedPos) {
           header.classList.add("fixed");
         } else {


### PR DESCRIPTION
## 概要
ページヘッダーの文字がヘッダーの文字の下端に到達するまでスクロールしたら
デザインが切り替わるように調整。

## 改善したい点
ヘッダー全体の高さとロゴとの間隔について実数値をとっている。
ロゴの位置か高さをJSで取得できれば解消できそう。
