### PR TITLE
fix: [program] 閉じるボタンでモーダルを閉じた際にactiveクラスが外れるようにする

### DIFF
--- a/src/components/parts/Modal.astro
+++ b/src/components/parts/Modal.astro
@@ -166,6 +166,7 @@
 
     function closeModal() {
       if (modal){
+        modal.classList.remove("-active");
         modal.style.display = "none";
       }
     }


### PR DESCRIPTION
## やりたいこと
閉じるボタンでモーダルを閉じた際、スクロールが効かない状態になっているため
スクロールが効くようにする

## やったこと
closeModal関数について、modalのactiveクラスを除く処理を追加